### PR TITLE
parameterize table names

### DIFF
--- a/scripts/sql/active-mmsis-v1.sql
+++ b/scripts/sql/active-mmsis-v1.sql
@@ -4,7 +4,7 @@ FROM
 (
   SELECT
     mmsi, count(*) as c_pos
-  FROM (TABLE_DATE_RANGE([pipeline_normalize.], TIMESTAMP('{{START_DATE}}'), TIMESTAMP('{{END_DATE}}')))
+  FROM (TABLE_DATE_RANGE([{normalize_table_name}.], TIMESTAMP('{start_date}'), TIMESTAMP('{end_date}')))
   WHERE
     lat IS NOT NULL AND lon IS NOT NULL
   GROUP BY

--- a/scripts/sql/likely-fishing-v2.sql
+++ b/scripts/sql/likely-fishing-v2.sql
@@ -5,7 +5,7 @@ select a.mmsi as mmsi from
     count(*) c_msg,
     sum (shiptype_text = 'Fishing') c_fishing,
     sum (shiptype_text = 'Fishing') / count(*) fishing_msg_ratio
-  FROM (TABLE_DATE_RANGE([pipeline_normalize.], TIMESTAMP('{{START_DATE}}'), TIMESTAMP('{{END_DATE}}')))
+  FROM (TABLE_DATE_RANGE([{normalize_table_name}.], TIMESTAMP('{start_date}'), TIMESTAMP('{end_date}')))
   WHERE
     type in (5, 24)
     and shiptype_text is not null
@@ -19,7 +19,7 @@ JOIN EACH
 (
   SELECT
     integer(mmsi) as mmsi, COUNT(*) AS c_pos
-  FROM (TABLE_DATE_RANGE([pipeline_normalize.], TIMESTAMP('{{START_DATE}}'), TIMESTAMP('{{END_DATE}}')))
+  FROM (TABLE_DATE_RANGE([{normalize_table_name}.], TIMESTAMP('{start_date}'), TIMESTAMP('{end_date}')))
   WHERE
     lat IS NOT NULL AND lon IS NOT NULL
     and mmsi not in (987357573,987357579,987357559,986737000,983712160,987357529) // helicopters

--- a/scripts/sql/spoofing-mmsis-v3.sql
+++ b/scripts/sql/spoofing-mmsis-v3.sql
@@ -24,7 +24,7 @@ FROM (
       COUNT(*) message_count,
       MIN(TIMESTAMP_TO_SEC(timestamp)) AS min_timestamp,
       MAX(TIMESTAMP_TO_SEC(timestamp)) AS max_timestamp
-    FROM (TABLE_DATE_RANGE([pipeline_classify_logistic_661b.], TIMESTAMP('{{START_DATE}}'), TIMESTAMP('{{END_DATE}}')))
+    FROM (TABLE_DATE_RANGE([{logistic_table_name}.], TIMESTAMP('{start_date}'), TIMESTAMP('{end_date}')))
     WHERE
       RIGHT(seg_id, 3) != 'BAD'
     GROUP BY
@@ -43,7 +43,7 @@ JOIN (
       COUNT(*) AS message_count,
       MIN(TIMESTAMP_TO_SEC(timestamp)) AS min_timestamp,
       MAX(TIMESTAMP_TO_SEC(timestamp)) AS max_timestamp
-    FROM (TABLE_DATE_RANGE([pipeline_classify_logistic_661b.], TIMESTAMP('{{START_DATE}}'), TIMESTAMP('{{END_DATE}}')))
+    FROM (TABLE_DATE_RANGE([{logistic_table_name}.], TIMESTAMP('{start_date}'), TIMESTAMP('{end_date}')))
     WHERE
       RIGHT(seg_id, 3) != 'BAD'
     GROUP BY

--- a/scripts/update_filter_lists.py
+++ b/scripts/update_filter_lists.py
@@ -4,6 +4,7 @@ import bqtools
 import treniformis
 import os
 import six
+import yaml
 
 
 def copy_to_sorted_mmsi(source_path, dest_path):
@@ -90,6 +91,10 @@ top_dir = os.path.abspath(os.path.join(this_dir, ".."))
 asset_dir = os.path.join(top_dir, "treniformis/_assets")
 tmp_path = os.path.join(top_dir, "temp", "temp_bigq_download")
 
+config_path = os.path.join(this_dir, "update_filter_lists_config.yml")
+with open(config_path) as f:
+    config = yaml.load(f)
+
 
 def update_base_lists():
     """update lists derived for BiqQuery
@@ -106,8 +111,7 @@ def update_base_lists():
         for date_range in fl.date_ranges:
             start_date, end_date = date_range
             year = start_date[:4]
-            query = (sql.replace("{{START_DATE}}", start_date).
-                         replace("{{END_DATE}}", end_date))
+            query = sql.format(start_date=start_date, end_date=end_date, **config)
             gcs_path = gcs_path_template.format(len(path_map))
             path_map[gcs_path] = (fl.path, year)
             queries.append(dict(

--- a/scripts/update_filter_lists_config.yml
+++ b/scripts/update_filter_lists_config.yml
@@ -1,0 +1,2 @@
+normalize_table_name: pipeline_normalize
+logistic_table_name: pipeline_classify_logistic_661b


### PR DESCRIPTION
Closes #21

* Parameterize table names in SQL files

* Create config file for table names

After this is merged, I plan to update the table names, rerun and cut another release.

@pwoods25443 a couple of questions:

 *  I did not parameterize the table names in the known_fishing queries as those tables looked like
    they might be stable and there is already one query per year.  Is that reasonable?

* Currently some of the data in the other queries is being pulled from `pipeline_normalize` and some
  from `pipeline_classify_logistic_661b`. Do you recall if there is a reason for this, or can I try to
  consolidate these down to a single table?